### PR TITLE
feat: Arrow a Row寄せ — 縦軸の射撃・敵進行 (Issue #7)

### DIFF
--- a/Assets/Prefabs/Enemies/Enemy.prefab
+++ b/Assets/Prefabs/Enemies/Enemy.prefab
@@ -107,7 +107,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Enemy
   moveSpeed: 2.5
-  destroyX: -12
+  destroyBottomY: -8
 --- !u!61 &6263873265096250781
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -151,8 +151,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::EnemySpawner
   enemyPrefab: {fileID: 379069980486720469, guid: dba4e71dff536cd4fba8bcbb488677ee, type: 3}
   spawnInterval: 1.2
-  spawnX: 9
-  spawnYRange: {x: -3.5, y: 3.5}
+  spawnTopY: 5.5
+  spawnXRange: {x: -4, y: 4}
 --- !u!114 &79056270
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,7 +309,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::PlayerShooter
   bulletPrefab: {fileID: 3341978287405458441, guid: cca616f8489aa21409033453a1dfd63f, type: 3}
   fireInterval: 0.35
-  spawnOffset: {x: 0.5, y: 0}
+  spawnOffset: {x: 0, y: 0.5}
 --- !u!114 &1965507464
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -391,7 +391,7 @@ Transform:
   m_GameObject: {fileID: 1965507462}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: -3.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/Combat/Bullet.cs
+++ b/Assets/Scripts/Combat/Bullet.cs
@@ -9,7 +9,7 @@ public sealed class Bullet : MonoBehaviour
     [SerializeField] private float maxLifetime = 3f;
 
     private float _elapsed;
-    private Vector3 _direction = Vector3.right;
+    private Vector3 _direction = Vector3.up;
 
     public void Initialize(Vector3 direction)
     {

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -1,17 +1,17 @@
 using UnityEngine;
 
 /// <summary>
-/// 左方向へ移動し、Bullet と衝突したら消える Enemy 最小実装。
+/// 下方向へ移動し、Bullet と衝突したら消える Enemy 最小実装（Arrow a Row 寄せ）。
 /// </summary>
 public sealed class Enemy : MonoBehaviour
 {
     [SerializeField] private float moveSpeed = 2.5f;
-    [SerializeField] private float destroyX = -12f;
+    [SerializeField] private float destroyBottomY = -8f;
 
     private void Update()
     {
-        transform.position += Vector3.left * moveSpeed * Time.deltaTime;
-        if (transform.position.x <= destroyX)
+        transform.position += Vector3.down * moveSpeed * Time.deltaTime;
+        if (transform.position.y <= destroyBottomY)
             Destroy(gameObject);
     }
 

--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -1,14 +1,14 @@
 using UnityEngine;
 
 /// <summary>
-/// 右側から一定間隔で Enemy を出現させる最小スポナー。
+/// 画面上側から一定間隔で Enemy を出現させる最小スポナー（Arrow a Row 寄せ）。
 /// </summary>
 public sealed class EnemySpawner : MonoBehaviour
 {
     [SerializeField] private Enemy enemyPrefab;
     [SerializeField] private float spawnInterval = 1.2f;
-    [SerializeField] private float spawnX = 9f;
-    [SerializeField] private Vector2 spawnYRange = new Vector2(-3.5f, 3.5f);
+    [SerializeField] private float spawnTopY = 5.5f;
+    [SerializeField] private Vector2 spawnXRange = new Vector2(-4f, 4f);
 
     private float _cooldown;
 
@@ -27,8 +27,8 @@ public sealed class EnemySpawner : MonoBehaviour
         if (enemyPrefab == null)
             return;
 
-        float spawnY = Random.Range(spawnYRange.x, spawnYRange.y);
-        var position = new Vector3(spawnX, spawnY, 0f);
+        float spawnX = Random.Range(spawnXRange.x, spawnXRange.y);
+        var position = new Vector3(spawnX, spawnTopY, 0f);
         Instantiate(enemyPrefab, position, Quaternion.identity);
     }
 }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 
 /// <summary>
-/// 左右移動のみ（キーボード A/D または 矢印）。
+/// 左右移動のみ（A/D または左右矢印）。W/S や上下矢印は使わない。
 /// </summary>
 public sealed class PlayerMovement : MonoBehaviour
 {

--- a/Assets/Scripts/Player/PlayerShooter.cs
+++ b/Assets/Scripts/Player/PlayerShooter.cs
@@ -1,13 +1,13 @@
 using UnityEngine;
 
 /// <summary>
-/// 一定間隔で右方向へ弾を自動発射する。
+/// 一定間隔で上方向へ弾を自動発射する（Arrow a Row 寄せ）。
 /// </summary>
 public sealed class PlayerShooter : MonoBehaviour
 {
     [SerializeField] private Bullet bulletPrefab;
     [SerializeField] private float fireInterval = 0.35f;
-    [SerializeField] private Vector2 spawnOffset = new Vector2(0.5f, 0f);
+    [SerializeField] private Vector2 spawnOffset = new Vector2(0f, 0.5f);
 
     private float _cooldown;
 
@@ -26,6 +26,6 @@ public sealed class PlayerShooter : MonoBehaviour
             return;
         var position = transform.position + (Vector3)spawnOffset;
         var bullet = Instantiate(bulletPrefab, position, Quaternion.identity);
-        bullet.Initialize(Vector3.right);
+        bullet.Initialize(Vector3.up);
     }
 }


### PR DESCRIPTION
## 概要
Issue #7: 弾を上向き、敵を上から下へ。プレイヤーは左右のみ。

## 変更
- \PlayerShooter\ / \Bullet\: 上向き
- \Enemy\ / \EnemySpawner\: 上スポーン・下進行
- \GameScene\ / \Enemy.prefab\: スポーン・破棄・Player 位置の調整
- \PlayerMovement\: コメント（W/S 不使用）

## Issue
Closes #7