### PR TITLE
feat: プレイヤー連続左右移動（仕様修正・2レーン廃止）

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -323,6 +323,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerMovement
   moveSpeed: 5
+  minMoveX: -4
+  maxMoveX: 4
 --- !u!212 &1965507465
 SpriteRenderer:
   serializedVersion: 2

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -2,11 +2,13 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 
 /// <summary>
-/// 左右移動のみ（A/D または左右矢印）。W/S や上下矢印は使わない。
+/// 左右の連続移動のみ（A/D または左右矢印）。W/S や上下矢印は使わない。
 /// </summary>
 public sealed class PlayerMovement : MonoBehaviour
 {
     [SerializeField] private float moveSpeed = 5f;
+    [SerializeField] private float minMoveX = -4f;
+    [SerializeField] private float maxMoveX = 4f;
 
     private void Update()
     {
@@ -22,6 +24,7 @@ public sealed class PlayerMovement : MonoBehaviour
 
         var pos = transform.position;
         pos.x += horizontal * moveSpeed * Time.deltaTime;
+        pos.x = Mathf.Clamp(pos.x, minMoveX, maxMoveX);
         transform.position = pos;
     }
 }


### PR DESCRIPTION
## 概要
仕様変更に伴い、2レーン固定ではなく **A/D・左右キーでの連続横移動** に戻します。

## 変更
- \PlayerMovement\: \moveSpeed\、\minMoveX\ / \maxMoveX\（\EnemySpawner\ の spawn 幅に合わせ -4〜4）
- \GameScene\: Player 初期位置を中央（x=0）、上記パラメータをシーンに反映

## 維持
- 上向き射撃・敵の上から下への流れ・HP / Result 遷移は未変更

## 備考
- バフ選択オブジェクト等は含みません