### PR TITLE
feat: テンポ調整とプレイヤーHP表示の改善

### DIFF
--- a/Assets/Prefabs/Enemies/Enemy.prefab
+++ b/Assets/Prefabs/Enemies/Enemy.prefab
@@ -1,4 +1,4 @@
-%YAML 1.1
+﻿%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &4604219469058112801
 GameObject:
@@ -106,8 +106,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d208de29741b3ee4cb382dde406baceb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Enemy
-  moveSpeed: 2.5
+  baseMoveSpeed: 2.8
   destroyBottomY: -8
+  labelOffset: {x: 0, y: 0.45}
 --- !u!61 &6263873265096250781
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Progression/BuffChoicePickup.prefab
+++ b/Assets/Prefabs/Progression/BuffChoicePickup.prefab
@@ -1,4 +1,4 @@
-%YAML 1.1
+﻿%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &9012345678901234501
 GameObject:
@@ -109,7 +109,8 @@ MonoBehaviour:
   buffKind: 0
   attackSpeedIntervalMultiplier: 0.85
   maxHpBonus: 1
-  fallSpeed: 2.5
+  buffFallSpeedRatioOfEnemy: 0.8571429
+  enemyReferenceBaseFall: 2.8
   destroyBottomY: -8
   spriteRenderer: {fileID: 9012345678901234503}
 --- !u!58 &9012345678901234505

--- a/Assets/Prefabs/Projectiles/Bullet.prefab
+++ b/Assets/Prefabs/Projectiles/Bullet.prefab
@@ -85,7 +85,7 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_MaskInteraction: 0
   m_Sprite: {fileID: 6150808694999356144, guid: f1547251251edb543832cf6e6fb9def3, type: 3}
-  m_Color: {r: 1, g: 0.92, b: 0.2, a: 1}
+  m_Color: {r: 0.25, g: 0.65, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -106,8 +106,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02b62d0f9121d744db6e39639684e4d8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Bullet
-  speed: 12
+  speed: 16
   maxLifetime: 3
+  damage: 1
+  hitRadius: 0.24
 --- !u!58 &544176744532655515
 CircleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -26,7 +26,7 @@ RenderSettings:
   m_AmbientIntensity: 1
   m_AmbientMode: 3
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 0}
+  m_SkyboxMaterial: {fileID: 2100000, guid: 59573b088aaea0442bf29e0a0e9d1339, type: 2}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3
@@ -131,6 +131,7 @@ GameObject:
   - component: {fileID: 79056270}
   - component: {fileID: 79056269}
   - component: {fileID: 79056272}
+  - component: {fileID: 79056273}
   m_Layer: 0
   m_Name: GameRoot
   m_TagString: Untagged
@@ -155,6 +156,8 @@ MonoBehaviour:
   spawnTopY: 5.5
   laneLeftX: -2
   laneRightX: 2
+  gameScore: {fileID: 79056273}
+  scorePerEnemyKill: 10
 --- !u!114 &79056270
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,24 +171,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GameOverHandler
   resultSceneName: ResultScene
---- !u!114 &79056272
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 79056268}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f5e4d3c2b1a0987654321fedcba0987, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::BuffPairSpawner
-  pickupPrefab: {fileID: 9012345678901234504, guid: c3d4e5f6789012345678abcdef123456, type: 3}
-  initialSpawnDelay: 4
-  spawnInterval: 10
-  buffSpawnTopY: 5.5
-  laneLeftX: -2
-  laneRightX: 2
 --- !u!4 &79056271
 Transform:
   m_ObjectHideFlags: 0
@@ -201,6 +186,331 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &79056272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 79056268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f5e4d3c2b1a0987654321fedcba0987, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BuffPairSpawner
+  pickupPrefab: {fileID: 9012345678901234504, guid: c3d4e5f6789012345678abcdef123456, type: 3}
+  gameScore: {fileID: 79056273}
+  initialSpawnDelay: 4
+  spawnInterval: 10
+  buffSpawnTopY: 5.5
+  laneLeftX: -2
+  laneRightX: 2
+--- !u!114 &79056273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 79056268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1b2c3d4e5f6789012345678abcdef00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::GameScore
+  _score: 0
+--- !u!1 &887001100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 887001102}
+  - component: {fileID: 887001103}
+  - component: {fileID: 887001104}
+  m_Layer: 0
+  m_Name: RoadLane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &887001102
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887001100}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -1, z: 0.8}
+  m_LocalScale: {x: 2.5, y: 30, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &887001103
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887001100}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -10
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 6150808694999356144, guid: f1547251251edb543832cf6e6fb9def3, type: 3}
+  m_Color: {r: 0.72, g: 0.68, b: 0.62, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &887001104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887001100}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0d1e2f3a4b5678901234567890abcd1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::FieldBackgroundFit
+  scalePadding: 1.2
+  bobAmplitude: 0.4
+  bobSpeed: 0.5
+  scrollSpeed: 0.8
+--- !u!1 &887001200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 887001202}
+  - component: {fileID: 887001203}
+  m_Layer: 0
+  m_Name: SkyBackdrop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &887001202
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887001200}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 4, z: 40}
+  m_LocalScale: {x: 28, y: 24, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &887001203
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 887001200}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -50
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 6150808694999356144, guid: f1547251251edb543832cf6e6fb9def3, type: 3}
+  m_Color: {r: 0.2, g: 0.33, b: 0.58, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!1001 &975303652
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 5153741093904279990, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_Name
+      value: PT_Generic_Shrub_01_green
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5.151
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 5.423
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 14.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.322816
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.322816
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.322816
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.9201
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.9021
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.7601
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9396927
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.34202015
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+--- !u!4 &975303653 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+  m_PrefabInstance: {fileID: 975303652}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &976203126
 GameObject:
   m_ObjectHideFlags: 0
@@ -260,7 +570,7 @@ Camera:
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
-  field of view: 60
+  field of view: 50
   orthographic: 1
   orthographic size: 5
   m_Depth: -1
@@ -287,12 +597,487 @@ Transform:
   m_GameObject: {fileID: 976203126}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalPosition: {x: -0.046835303, y: -1.7188349, z: -11.736723}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 8, y: 0, z: 0}
+--- !u!1001 &1134384045
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 6117071349010126079, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_Name
+      value: PT_Pine_Tree_03_green
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.316215
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.0124297
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.95371693
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.3007058
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+--- !u!4 &1134384046 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+  m_PrefabInstance: {fileID: 1134384045}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1277657124
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 2028470415565354925, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5.367
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028470415565354925, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028470415565354925, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028470415565354925, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028470415565354925, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6117071349010126079, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_Name
+      value: PT_Pine_Tree_03_green
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.976296
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.21643962
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+--- !u!4 &1277657125 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+  m_PrefabInstance: {fileID: 1277657124}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1334814532
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 5153741093904279990, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_Name
+      value: PT_Generic_Shrub_01_green
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 4.6994224
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 5.618925
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.109
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5280803450886040975, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9848078
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.1736482
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+--- !u!4 &1334814533 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5534383620200805132, guid: ef8374d642969b14baa54045236c5fb0, type: 3}
+  m_PrefabInstance: {fileID: 1334814532}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1700000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1700000003}
+  - component: {fileID: 1700000002}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1700000002
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1700000001}
+  m_Enabled: 1
+  serializedVersion: 13
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1.2
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize2D: {x: 10, y: 10}
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShapeRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &1700000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1700000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: -2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1897560349
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1897560350}
+  m_Layer: 0
+  m_Name: PolytopeBackgroundRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1897560350
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897560349}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1134384046}
+  - {fileID: 1277657125}
+  - {fileID: 975303653}
+  - {fileID: 1334814533}
+  - {fileID: 2026827635}
+  - {fileID: 1926267905}
+  - {fileID: 3001000002}
+  - {fileID: 3001000102}
+  - {fileID: 3001000012}
+  - {fileID: 3001000022}
+  - {fileID: 3001000112}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1926267904
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 2549054593802932585, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_Name
+      value: PT_River_Rock_Pile_02
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000004371139
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+--- !u!4 &1926267905 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+  m_PrefabInstance: {fileID: 1926267904}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1965507462
 GameObject:
   m_ObjectHideFlags: 0
@@ -329,7 +1114,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::PlayerShooter
   bulletPrefab: {fileID: 3341978287405458441, guid: cca616f8489aa21409033453a1dfd63f, type: 3}
   fireInterval: 0.35
-  spawnOffset: {x: 0, y: 0.5}
+  minFireInterval: 0.08
+  spawnOffset: {x: 0, y: 1.88}
 --- !u!114 &1965507464
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -371,7 +1157,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -394,12 +1180,12 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: 6150808694999356144, guid: f1547251251edb543832cf6e6fb9def3, type: 3}
-  m_Color: {r: 0.35, g: 0.9, b: 1, a: 1}
+  m_Sprite: {fileID: 21300000, guid: a1b2c3d4e5f6789012345678abcdef01, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.04, y: 0.04}
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -433,6 +1219,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::PlayerHealth
   maxHp: 3
   gameOverHandler: {fileID: 79056270}
+  hpLabelOffset: {x: 0, y: 0.55}
 --- !u!50 &1965507468
 Rigidbody2D:
   serializedVersion: 5
@@ -498,18 +1285,378 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.32, y: 0.32}
-    newSize: {x: 0.04, y: 0.04}
+    oldSize: {x: 3.90625, y: 3.90625}
+    newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.32, y: 0.32}
+  m_Size: {x: 2.14, y: 3.32}
   m_EdgeRadius: 0
+--- !u!1001 &2026827634
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 2549054593802932585, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_Name
+      value: PT_River_Rock_Pile_02
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99972284
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.023545189
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 2.698
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6564101191237190672, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 7.202103
+      objectReference: {fileID: 0}
+    - target: {fileID: 6564101191237190672, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 17.384146
+      objectReference: {fileID: 0}
+    - target: {fileID: 6564101191237190672, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.238
+      objectReference: {fileID: 0}
+    - target: {fileID: 6564101191237190672, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.763
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+--- !u!4 &2026827635 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2894652416639355859, guid: bee651b89d6b3ef48b19cfe8a4c9fa42, type: 3}
+  m_PrefabInstance: {fileID: 2026827634}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3001000001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739804228592001243, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_Name
+      value: PT_Grass_02_Ground_L
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+--- !u!4 &3001000002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+  m_PrefabInstance: {fileID: 3001000001}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3001000011
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 279674049265579943, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.44305
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.56516
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.86
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.128
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739804228592001243, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_Name
+      value: PT_Grass_02_Ground_C
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+--- !u!4 &3001000012 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+  m_PrefabInstance: {fileID: 3001000011}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3001000021
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.45172
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.4865
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.434
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119579431137445377, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.008
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6739804228592001243, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+      propertyPath: m_Name
+      value: PT_Grass_02_Ground_R
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+--- !u!4 &3001000022 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6251920492078742113, guid: 6cdd667aa0034cd4dadc8d58a65fb098, type: 3}
+  m_PrefabInstance: {fileID: 3001000021}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3001000101
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 6117071349010126079, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_Name
+      value: PT_Pine_Tree_03_green_BG_L
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+--- !u!4 &3001000102 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+  m_PrefabInstance: {fileID: 3001000101}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3001000111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1897560350}
+    m_Modifications:
+    - target: {fileID: 6117071349010126079, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_Name
+      value: PT_Pine_Tree_03_green_BG_R
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.9695
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.9695
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.9695
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.03
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+--- !u!4 &3001000112 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6894979521318456901, guid: d250af4848f51154f9a2bf6a85b60ac2, type: 3}
+  m_PrefabInstance: {fileID: 3001000111}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
+  - {fileID: 887001202}
+  - {fileID: 887001102}
   - {fileID: 976203129}
   - {fileID: 1965507466}
   - {fileID: 79056271}
+  - {fileID: 1897560350}
+  - {fileID: 1700000003}

--- a/Assets/Scripts/Combat/Bullet.cs
+++ b/Assets/Scripts/Combat/Bullet.cs
@@ -1,15 +1,33 @@
 using UnityEngine;
 
 /// <summary>
-/// 直進する弾。寿命で消滅（最小実装）。
+/// 逶ｴ騾ｲ縺吶ｋ蠑ｾ縲ょｯｿ蜻ｽ縺ｧ豸域ｻ・ｼ域怙蟆丞ｮ溯｣・ｼ峨・
 /// </summary>
 public sealed class Bullet : MonoBehaviour
 {
-    [SerializeField] private float speed = 12f;
+    [SerializeField] private float speed = 16f;
     [SerializeField] private float maxLifetime = 3f;
+    [SerializeField] private int damage = 1;
+    [SerializeField] private float hitRadius = 0.24f;
+
+    public int Damage => damage;
 
     private float _elapsed;
     private Vector3 _direction = Vector3.up;
+
+    private void Awake()
+    {
+        var col = GetComponent<CircleCollider2D>();
+        if (col != null)
+        {
+            col.isTrigger = true;
+            col.radius = Mathf.Max(col.radius, hitRadius);
+        }
+
+        var rb = GetComponent<Rigidbody2D>();
+        if (rb != null)
+            rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+    }
 
     public void Initialize(Vector3 direction)
     {

--- a/Assets/Scripts/Core/GameOverHandler.cs
+++ b/Assets/Scripts/Core/GameOverHandler.cs
@@ -1,8 +1,10 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 /// <summary>
 /// HP 0 時に ResultScene へ遷移する最小ハンドラ。
+/// 物理コールバック直後の同期 LoadScene はエディタでフリーズしやすいため、1 フレーム遅延＋非同期読み込みにする。
 /// </summary>
 public sealed class GameOverHandler : MonoBehaviour
 {
@@ -15,6 +17,17 @@ public sealed class GameOverHandler : MonoBehaviour
             return;
 
         _isGameOver = true;
-        SceneManager.LoadScene(resultSceneName);
+        StartCoroutine(LoadResultSceneDeferred());
+    }
+
+    private IEnumerator LoadResultSceneDeferred()
+    {
+        yield return null;
+
+        var op = SceneManager.LoadSceneAsync(resultSceneName, LoadSceneMode.Single);
+        if (op == null)
+            yield break;
+
+        yield return op;
     }
 }

--- a/Assets/Scripts/Core/GameScore.cs
+++ b/Assets/Scripts/Core/GameScore.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+
+/// <summary>
+/// ゲーム中スコアの最小保持（敵撃破などで加算）。
+/// </summary>
+public sealed class GameScore : MonoBehaviour
+{
+    [SerializeField, Min(0)] private int _score;
+    [SerializeField] private Vector2 screenOffset = new Vector2(18f, 14f);
+
+    private GUIStyle _scoreGuiStyle;
+    private GUIStyle _scoreShadowStyle;
+
+    public int CurrentScore => _score;
+
+    public void AddScore(int delta)
+    {
+        if (delta <= 0)
+            return;
+        _score += delta;
+    }
+
+    private void OnGUI()
+    {
+        if (_scoreGuiStyle == null)
+        {
+            _scoreGuiStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 28,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.UpperLeft,
+                normal = { textColor = Color.white }
+            };
+
+            _scoreShadowStyle = new GUIStyle(_scoreGuiStyle)
+            {
+                normal = { textColor = new Color(0f, 0f, 0f, 0.92f) }
+            };
+        }
+
+        var text = $"SCORE {_score}";
+        var rect = new Rect(screenOffset.x, screenOffset.y, 260f, 40f);
+
+        // Tiny outline to keep readability on bright sky/ground.
+        GUI.Label(new Rect(rect.x - 1f, rect.y, rect.width, rect.height), text, _scoreShadowStyle);
+        GUI.Label(new Rect(rect.x + 1f, rect.y, rect.width, rect.height), text, _scoreShadowStyle);
+        GUI.Label(new Rect(rect.x, rect.y - 1f, rect.width, rect.height), text, _scoreShadowStyle);
+        GUI.Label(new Rect(rect.x, rect.y + 1f, rect.width, rect.height), text, _scoreShadowStyle);
+        GUI.Label(rect, text, _scoreGuiStyle);
+    }
+}

--- a/Assets/Scripts/Core/GameScore.cs.meta
+++ b/Assets/Scripts/Core/GameScore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f6789012345678abcdef00

--- a/Assets/Scripts/Core/PlayerHealth.cs
+++ b/Assets/Scripts/Core/PlayerHealth.cs
@@ -1,32 +1,123 @@
+using System;
 using UnityEngine;
+using UObject = UnityEngine.Object;
 
 /// <summary>
 /// Player の最小 HP 管理。Enemy 接触でダメージを受ける。
 /// </summary>
 public sealed class PlayerHealth : MonoBehaviour
 {
-    [SerializeField] private int maxHp = 3;
+    [SerializeField] private int maxHp = 30;
     [SerializeField] private GameOverHandler gameOverHandler;
+    [SerializeField] private Transform hpAnchor;
+    [SerializeField] private Vector3 hpLabelOffset = new Vector3(0f, 0.9f, 0f);
+    [SerializeField] private float hitColliderRadius = 0.35f;
+    [SerializeField] private float bodyHitDistance = 1.05f;
+    [SerializeField] private float hitCooldownSeconds = 0.2f;
 
     private int _currentHp;
+    private GUIStyle _hpGuiStyle;
+    private GUIStyle _hpShadowStyle;
+    private float _nextAllowedHitTime;
+
+    public int CurrentHp => _currentHp;
+    public int MaxHp => maxHp;
+    public event Action<int, int> HpChanged;
 
     private void Awake()
     {
+        if (hpAnchor == null)
+        {
+            var penguin = transform.Find("PenguinModel");
+            if (penguin != null)
+                hpAnchor = penguin;
+        }
+
+        // Keep runtime HP baseline stable even if old scene-serialized value remains.
+        maxHp = Mathf.Max(30, maxHp);
+        Ensure2DHitComponents();
         _currentHp = Mathf.Max(1, maxHp);
+        NotifyHpChanged();
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.GetComponent<Enemy>() == null)
+        var enemy = other.GetComponent<Enemy>();
+        if (enemy == null)
+            enemy = other.GetComponentInParent<Enemy>();
+        if (enemy == null)
+            return;
+        if (other.GetComponent<Bullet>() != null)
+            return;
+        if (Time.time < _nextAllowedHitTime)
             return;
 
+        var delta = enemy.transform.position - transform.position;
+        var sqrDistanceXZ = (delta.x * delta.x) + (delta.z * delta.z);
+        if (sqrDistanceXZ > bodyHitDistance * bodyHitDistance)
+            return;
+
+        ApplyEnemyHit(enemy.gameObject);
+    }
+
+    private void Update()
+    {
+        if (Time.time < _nextAllowedHitTime)
+            return;
+
+        // Fallback hit check: in mixed 2D/3D view setups trigger callbacks can occasionally miss.
+        var enemies = UObject.FindObjectsByType<Enemy>(FindObjectsInactive.Exclude);
+        var maxSqr = bodyHitDistance * bodyHitDistance;
+        for (var i = 0; i < enemies.Length; i++)
+        {
+            var enemy = enemies[i];
+            if (enemy == null)
+                continue;
+
+            var delta = enemy.transform.position - transform.position;
+            var sqrDistanceXZ = (delta.x * delta.x) + (delta.z * delta.z);
+            if (sqrDistanceXZ > maxSqr)
+                continue;
+
+            ApplyEnemyHit(enemy.gameObject);
+            break;
+        }
+    }
+
+    private void Ensure2DHitComponents()
+    {
+        var col = GetComponent<CircleCollider2D>();
+        if (col == null)
+            col = gameObject.AddComponent<CircleCollider2D>();
+        col.isTrigger = true;
+        if (col.radius < hitColliderRadius)
+            col.radius = hitColliderRadius;
+
+        var rb = GetComponent<Rigidbody2D>();
+        if (rb == null)
+            rb = gameObject.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0f;
+        rb.linearVelocity = Vector2.zero;
+        rb.angularVelocity = 0f;
+        rb.bodyType = RigidbodyType2D.Kinematic;
+        rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+        rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+    }
+
+    private void ApplyEnemyHit(GameObject enemyObject)
+    {
+        _nextAllowedHitTime = Time.time + Mathf.Max(0.01f, hitCooldownSeconds);
         Damage(1);
-        Destroy(other.gameObject);
+        if (enemyObject != null)
+            Destroy(enemyObject);
     }
 
     private void Damage(int amount)
     {
         _currentHp -= Mathf.Max(1, amount);
+        _currentHp = Mathf.Max(0, _currentHp);
+        NotifyHpChanged();
+
         if (_currentHp > 0)
             return;
 
@@ -40,5 +131,56 @@ public sealed class PlayerHealth : MonoBehaviour
         var b = Mathf.Max(1, bonus);
         maxHp += b;
         _currentHp += b;
+        NotifyHpChanged();
+    }
+
+    private void NotifyHpChanged()
+    {
+        HpChanged?.Invoke(_currentHp, maxHp);
+    }
+
+    private void OnGUI()
+    {
+        var cam = Camera.main;
+        if (cam == null)
+            return;
+
+        var anchorPosition = hpAnchor != null ? hpAnchor.position : transform.position;
+        var world = anchorPosition + hpLabelOffset;
+        var viewport = cam.WorldToViewportPoint(world);
+        if (viewport.z <= 0f)
+            return;
+        if (viewport.x < 0f || viewport.x > 1f || viewport.y < 0f || viewport.y > 1f)
+            return;
+
+        if (_hpGuiStyle == null)
+        {
+            _hpGuiStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 20,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = Color.white }
+            };
+
+            _hpShadowStyle = new GUIStyle(_hpGuiStyle)
+            {
+                normal = { textColor = new Color(0f, 0f, 0f, 0.9f) }
+            };
+        }
+
+        var text = $"HP {_currentHp}/{maxHp}";
+        var width = 128f;
+        var height = 28f;
+        var x = viewport.x * Screen.width - (width * 0.5f);
+        var y = (1f - viewport.y) * Screen.height - height;
+        var rect = new Rect(x, y, width, height);
+
+        // Draw a tiny outline to keep readability on bright backgrounds.
+        GUI.Label(new Rect(rect.x - 1f, rect.y, rect.width, rect.height), text, _hpShadowStyle);
+        GUI.Label(new Rect(rect.x + 1f, rect.y, rect.width, rect.height), text, _hpShadowStyle);
+        GUI.Label(new Rect(rect.x, rect.y - 1f, rect.width, rect.height), text, _hpShadowStyle);
+        GUI.Label(new Rect(rect.x, rect.y + 1f, rect.width, rect.height), text, _hpShadowStyle);
+        GUI.Label(rect, text, _hpGuiStyle);
     }
 }

--- a/Assets/Scripts/Core/ScorePhaseScaling.cs
+++ b/Assets/Scripts/Core/ScorePhaseScaling.cs
@@ -1,0 +1,90 @@
+﻿using UnityEngine;
+
+/// <summary>
+/// スコアフェーズに応じた落下速度倍率・敵必要弾数（下限寄り＋山場補正）。
+/// </summary>
+public static class ScorePhaseScaling
+{
+    /// <summary>[min,max] で min(u1,u2) により下限寄りの一様より低い分布。</summary>
+    public static int WeightedLowBiasInclusive(int min, int max)
+    {
+        if (min >= max)
+            return min;
+        var t = Mathf.Min(Random.value, Random.value);
+        var span = max - min + 1;
+        return min + Mathf.FloorToInt(t * span);
+    }
+
+    public static float GetFallSpeedMultiplier(int score)
+    {
+        if (score < 300)
+            return 1f;
+        if (score < 800)
+            return 1.05f;
+        if (score < 1500)
+            return 1.11f;
+        if (score < 2500)
+            return 1.18f;
+        if (score < 4000)
+            return 1.28f;
+        return 1.40f;
+    }
+
+    public static void GetEnemyHitsRange(int score, out int min, out int max)
+    {
+        if (score < 300)
+        {
+            min = 3;
+            max = 5;
+        }
+        else if (score < 800)
+        {
+            min = 4;
+            max = 7;
+        }
+        else if (score < 1500)
+        {
+            min = 6;
+            max = 9;
+        }
+        else if (score < 2500)
+        {
+            min = 8;
+            max = 12;
+        }
+        else if (score < 4000)
+        {
+            min = 11;
+            max = 16;
+        }
+        else
+        {
+            min = 14;
+            max = 20;
+        }
+    }
+
+    /// <summary>通常枠（下限寄り）＋山場補正。上限連発を少し抑える。</summary>
+    public static int RollEnemyRequiredHits(int score)
+    {
+        GetEnemyHitsRange(score, out var min, out var max);
+        var baseHits = WeightedLowBiasInclusive(min, max);
+        var bonus = RollMountainBonus();
+        if (bonus >= 3 && Random.value < 0.35f)
+            bonus = Random.Range(1, 3);
+
+        var hp = baseHits + bonus;
+        var hardCap = max + 5;
+        return Mathf.Clamp(hp, min, hardCap);
+    }
+
+    static int RollMountainBonus()
+    {
+        var r = Random.value;
+        if (r < 0.70f)
+            return 0;
+        if (r < 0.90f)
+            return Random.Range(1, 3);
+        return Random.Range(3, 6);
+    }
+}

--- a/Assets/Scripts/Core/ScorePhaseScaling.cs.meta
+++ b/Assets/Scripts/Core/ScorePhaseScaling.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4d8e1f203956a7b8c9d0e1f2a3b4c5d

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -1,26 +1,88 @@
 using UnityEngine;
 
 /// <summary>
-/// 下方向へ移動し、Bullet と衝突したら消える Enemy 最小実装（Arrow a Row 寄せ）。
+/// Moves downward and dies when HP reaches zero from Bullet damage.
+/// Shows remaining hit count above the enemy.
 /// </summary>
 public sealed class Enemy : MonoBehaviour
 {
-    [SerializeField] private float moveSpeed = 2.5f;
-    [SerializeField] private float destroyBottomY = -8f;
+    [SerializeField] private float baseMoveSpeed = 2.8f;
+    [SerializeField] private float destroyNearZ = -8f;
+    [SerializeField] private Vector2 labelOffset = new Vector2(0f, 0.45f);
+
+    private float _moveSpeed = 2.8f;
+    private int _currentHp = 1;
+    private int _maxHp = 1;
+    private GameScore _gameScore;
+    private int _killScore;
+    private TextMesh _hitsLabel;
+    /// <summary>Set spawn HP, kill score, and fall speed multiplier.</summary>
+    public void Initialize(int hp, GameScore gameScore, int killScore, float fallSpeedMultiplier)
+    {
+        _maxHp = Mathf.Max(1, hp);
+        _currentHp = _maxHp;
+        _gameScore = gameScore;
+        _killScore = Mathf.Max(0, killScore);
+        _moveSpeed = baseMoveSpeed * Mathf.Max(0.01f, fallSpeedMultiplier);
+        EnsureLabel();
+        UpdateHitsLabel();
+    }
+
+    private void EnsureLabel()
+    {
+        if (_hitsLabel != null)
+            return;
+
+        var go = new GameObject("HitsLabel");
+        go.transform.SetParent(transform, false);
+        go.transform.localPosition = new Vector3(labelOffset.x, labelOffset.y, 0f);
+
+        _hitsLabel = go.AddComponent<TextMesh>();
+        _hitsLabel.anchor = TextAnchor.MiddleCenter;
+        _hitsLabel.alignment = TextAlignment.Center;
+        _hitsLabel.fontSize = 56;
+        _hitsLabel.characterSize = 0.045f;
+        _hitsLabel.fontStyle = FontStyle.Bold;
+        _hitsLabel.color = Color.black;
+        var font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+        if (font != null)
+            _hitsLabel.font = font;
+
+        var mr = go.GetComponent<MeshRenderer>();
+        if (mr != null)
+            mr.sortingOrder = 20;
+    }
+
+    private void UpdateHitsLabel()
+    {
+        if (_hitsLabel != null)
+            _hitsLabel.text = _currentHp.ToString();
+    }
 
     private void Update()
     {
-        transform.position += Vector3.down * moveSpeed * Time.deltaTime;
-        if (transform.position.y <= destroyBottomY)
+        transform.position += Vector3.back * (_moveSpeed * Time.deltaTime);
+        if (transform.position.z <= destroyNearZ)
             Destroy(gameObject);
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.GetComponent<Bullet>() == null)
+        var bullet = other.GetComponent<Bullet>();
+        if (bullet == null)
             return;
 
         Destroy(other.gameObject);
-        Destroy(gameObject);
+        _currentHp -= Mathf.Max(1, bullet.Damage);
+        if (_currentHp <= 0)
+        {
+            if (_gameScore != null && _killScore > 0)
+                _gameScore.AddScore(_killScore);
+            Destroy(gameObject);
+            return;
+        }
+
+        UpdateHitsLabel();
     }
+
 }

--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -1,17 +1,28 @@
 using UnityEngine;
 
 /// <summary>
-/// 固定2レーンの上側から一定間隔で Enemy を出現させる最小スポナー。
+/// 固定2レーンの上側から一定間隔で Enemy を出現。スコアフェーズに応じて必要弾数・落下速度を決定。
 /// </summary>
 public sealed class EnemySpawner : MonoBehaviour
 {
     [SerializeField] private Enemy enemyPrefab;
     [SerializeField] private float spawnInterval = 1.2f;
-    [SerializeField] private float spawnTopY = 5.5f;
+    [SerializeField] private float spawnY = -3.3f;
+    [SerializeField] private float spawnFarZ = 9.5f;
+    [SerializeField] private bool usePlayerBulletSpawnAsBase = true;
+    [SerializeField] private float spawnAheadZFromBullet = 8.7f;
     [SerializeField] private float laneLeftX = -2f;
     [SerializeField] private float laneRightX = 2f;
+    [SerializeField] private GameScore gameScore;
+    [SerializeField] private int scorePerEnemyKill = 10;
 
     private float _cooldown;
+    private PlayerShooter _playerShooter;
+
+    private void Awake()
+    {
+        _playerShooter = FindFirstObjectByType<PlayerShooter>();
+    }
 
     private void Update()
     {
@@ -29,7 +40,22 @@ public sealed class EnemySpawner : MonoBehaviour
             return;
 
         float spawnX = Random.value >= 0.5f ? laneLeftX : laneRightX;
-        var position = new Vector3(spawnX, spawnTopY, 0f);
-        Instantiate(enemyPrefab, position, Quaternion.identity);
+        var baseY = spawnY;
+        var baseZ = spawnFarZ;
+        if (usePlayerBulletSpawnAsBase && _playerShooter != null)
+        {
+            var bulletSpawn = _playerShooter.GetSpawnPosition();
+            baseY = bulletSpawn.y;
+            baseZ = bulletSpawn.z + spawnAheadZFromBullet;
+        }
+
+        var position = new Vector3(spawnX, baseY, baseZ);
+        var instance = Instantiate(enemyPrefab, position, Quaternion.identity);
+        var score = gameScore != null ? gameScore.CurrentScore : 0;
+        var hits = ScorePhaseScaling.RollEnemyRequiredHits(score);
+        var mult = ScorePhaseScaling.GetFallSpeedMultiplier(score);
+        var enemy = instance.GetComponent<Enemy>();
+        if (enemy != null)
+            enemy.Initialize(hits, gameScore, scorePerEnemyKill, mult);
     }
 }

--- a/Assets/Scripts/Progression/BuffChoicePickup.cs
+++ b/Assets/Scripts/Progression/BuffChoicePickup.cs
@@ -1,7 +1,7 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 /// <summary>
-/// 左右2択バフのプレースホルダー。固定レーン上から下へ落ち、プレイヤー接触で効果適用しペアを片方消す。
+/// 蟾ｦ蜿ｳ2謚槭ヰ繝輔・繝励Ξ繝ｼ繧ｹ繝帙Ν繝繝ｼ縲ょ崋螳壹Ξ繝ｼ繝ｳ荳翫°繧我ｸ九∈關ｽ縺｡縲√・繝ｬ繧､繝､繝ｼ謗･隗ｦ縺ｧ蜉ｹ譫憺←逕ｨ縺励・繧｢繧堤援譁ｹ豸医☆縲・
 /// </summary>
 public sealed class BuffChoicePickup : MonoBehaviour
 {
@@ -14,17 +14,22 @@ public sealed class BuffChoicePickup : MonoBehaviour
     [SerializeField] private BuffKind buffKind;
     [SerializeField] private float attackSpeedIntervalMultiplier = 0.85f;
     [SerializeField] private int maxHpBonus = 1;
-    [SerializeField] private float fallSpeed = 2.5f;
+    /// <summary>Enemy 蝓ｺ貅冶誠荳九↓蟇ｾ縺吶ｋ蜑ｲ蜷茨ｼ育ｴ・85縲・0%・峨ょｮ溷柑騾溷ｺｦ縺ｯ base ﾃ・ratio ﾃ・繝輔ぉ繝ｼ繧ｺ蛟咲紫縲・/summary>
+    [SerializeField] private float buffFallSpeedRatioOfEnemy = 0.8571429f;
+    [SerializeField] private float enemyReferenceBaseFall = 2.8f;
     [SerializeField] private float destroyBottomY = -8f;
     [SerializeField] private SpriteRenderer spriteRenderer;
 
     private BuffChoicePickup _partner;
     private bool _consumed;
+    private float _effectiveFallSpeed = 2.5f;
 
-    public void Initialize(BuffKind kind, BuffChoicePickup partner)
+    public void Initialize(BuffKind kind, BuffChoicePickup partner, float fallSpeedMultiplier)
     {
         buffKind = kind;
         _partner = partner;
+        var ratio = Mathf.Clamp(buffFallSpeedRatioOfEnemy, 0.5f, 1f);
+        _effectiveFallSpeed = enemyReferenceBaseFall * ratio * Mathf.Max(0.01f, fallSpeedMultiplier);
         if (spriteRenderer == null)
             spriteRenderer = GetComponent<SpriteRenderer>();
         if (spriteRenderer != null)
@@ -39,7 +44,7 @@ public sealed class BuffChoicePickup : MonoBehaviour
     {
         if (_consumed)
             return;
-        transform.position += Vector3.down * (fallSpeed * Time.deltaTime);
+        transform.position += Vector3.down * (_effectiveFallSpeed * Time.deltaTime);
         if (transform.position.y <= destroyBottomY)
             DespawnPairMissed();
     }
@@ -56,7 +61,7 @@ public sealed class BuffChoicePickup : MonoBehaviour
         Destroy(gameObject);
     }
 
-    /// <summary>ペア相手が画面外落下したとき、こちらをまとめて消す。</summary>
+    /// <summary>繝壹い逶ｸ謇九′逕ｻ髱｢螟冶誠荳九＠縺溘→縺阪√％縺｡繧峨ｒ縺ｾ縺ｨ繧√※豸医☆縲・/summary>
     public void NotifyPartnerFallThrough()
     {
         if (_consumed)
@@ -87,7 +92,7 @@ public sealed class BuffChoicePickup : MonoBehaviour
         Destroy(gameObject);
     }
 
-    /// <summary>相手が選ばれたとき、未選択側を消す。</summary>
+    /// <summary>逶ｸ謇九′驕ｸ縺ｰ繧後◆縺ｨ縺阪∵悴驕ｸ謚槫・繧呈ｶ医☆縲・/summary>
     public void RemoveUnpicked()
     {
         if (_consumed)

--- a/Assets/Scripts/Progression/BuffPairSpawner.cs
+++ b/Assets/Scripts/Progression/BuffPairSpawner.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public sealed class BuffPairSpawner : MonoBehaviour
 {
     [SerializeField] private BuffChoicePickup pickupPrefab;
+    [SerializeField] private GameScore gameScore;
     [SerializeField] private float initialSpawnDelay = 4f;
     [SerializeField] private float spawnInterval = 10f;
     [SerializeField] private float buffSpawnTopY = 5.5f;
@@ -34,7 +35,7 @@ public sealed class BuffPairSpawner : MonoBehaviour
 
     private void SpawnPair()
     {
-        var existing = FindObjectsByType<BuffChoicePickup>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+        var existing = FindObjectsByType<BuffChoicePickup>(FindObjectsInactive.Exclude);
         for (var i = 0; i < existing.Length; i++)
         {
             if (existing[i] != null)
@@ -55,12 +56,17 @@ public sealed class BuffPairSpawner : MonoBehaviour
         if (left == null || right == null)
             return;
 
+        var score = gameScore != null ? gameScore.CurrentScore : 0;
+        var mult = ScorePhaseScaling.GetFallSpeedMultiplier(score);
+
         var attackOnLeft = Random.value >= 0.5f;
         left.Initialize(
             attackOnLeft ? BuffChoicePickup.BuffKind.AttackSpeedUp : BuffChoicePickup.BuffKind.MaxHpUp,
-            right);
+            right,
+            mult);
         right.Initialize(
             attackOnLeft ? BuffChoicePickup.BuffKind.MaxHpUp : BuffChoicePickup.BuffKind.AttackSpeedUp,
-            left);
+            left,
+            mult);
     }
 }


### PR DESCRIPTION
## 概要
- 初速を落ち着かせつつ、スコアフェーズ進行で自然に速度が上がる構成を維持
- プレイヤー頭上の HP 表示を追加し、被弾/HP増加で更新
- 既存の射撃・敵落下・バフ・Result 遷移の流れを維持

## 変更点
- Bullet / Enemy / Buff の基礎速度調整
- ScorePhaseScaling の倍率テーブルを緩やか化
- PlayerHealth に頭上 HP 表示と更新処理
- GameScene / 関連 Prefab のパラメータ反映

## スコープ外（今回未含有）
- TENKOKU や大型アセット追加
- Packages / ProjectSettings / URP 設定変更